### PR TITLE
reuse chrome process in aws lambda

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -6,19 +6,35 @@ bin/pdfserver: standalone.go src/snapper/pdfprinter.go src/snapper/chrome.go
 bin/linux/pdfserver: standalone.go src/snapper/pdfprinter.go src/snapper/chrome.go
 	GOOS=linux go build -o bin/linux/pdfserver standalone.go
 
+.PHONY: bin/linux/lambda
 bin/linux/lambda: lambda.go src/snapper/pdfprinter.go src/snapper/chrome.go
 	GOOS=linux go build -o bin/linux/lambda lambda.go
 
+.PHONY: assets/headless-chrome
 assets/headless-chrome:
 	mkdir -p assets
+	cd assets && rm -rf headless-chrome
+	cd assets && rm stable-headless-chromium* || true
+
 	# using a version newer than chrome 64 (e.g. chrome 65) currently does not work
+	# v1.0.0-38/stable-headless-chromium-amazonlinux-2017-03.zip
 	cd assets && wget https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-38/stable-headless-chromium-amazonlinux-2017-03.zip
-	cd assets && unzip stable-headless-chromium-amazonlinux-2017-03.zip
+	cd assets && unzip stable-headless-chromium-amazonlinux-2017-03
+
+	# v1.0.0-39/stable-headless-chromium-amazonlinux-2017-03.zip
+	# cd assets && wget https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-39/stable-headless-chromium-amazonlinux-2017-03.zip
+	# cd assets && unzip stable-headless-chromium-amazonlinux-2017-03.zip
+
+	# v1.0.0-57/stable-headless-chromium-amazonlinux-2.zip
+	# cd assets && wget https://github.com/adieuadieu/serverless-chrome/releases/download/v1.0.0-57/stable-headless-chromium-amazonlinux-2.zip
+	# cd assets && unzip stable-headless-chromium-amazonlinux-2.zip
+
 	mkdir -p assets/headless-chrome && mv assets/headless-chromium assets/headless-chrome/headless_shell
 
+.PHONY: snapper.zip
 snapper.zip: bin/linux/lambda lambda.go src/snapper/pdfprinter.go src/snapper/chrome.go assets/headless-chrome
 	cp bin/linux/lambda assets
-	cd assets && rm -f snapper.zip && zip -r snapper.zip lambda headless-chrome
+	cd assets && rm -f snapper*.zip && zip -r snapper_v2.zip lambda headless-chrome
 
 S3_BUCKET?=us-west-1.tony.angerilli.ca
 S3_KEY?=lambda/snapper.zip
@@ -26,7 +42,7 @@ upload-lambda: snapper.zip
 	aws s3 cp assets/snapper.zip s3://$(S3_BUCKET)/$(S3_KEY)
 
 update-lambda: snapper.zip
-	aws lambda update-function-code --function-name snapper-pdf-printer --zip-file fileb://./assets/snapper.zip --region us-east-1
+	aws lambda update-function-code --function-name snapper-pdf-printer --zip-file fileb://./assets/snapper_v2.zip --region us-east-1
 
 docker-image: bin/linux/pdfserver standalone.go src/snapper/pdfprinter.go src/snapper/chrome.go
 	cp bin/linux/pdfserver assets

--- a/server/src/snapper/chrome.go
+++ b/server/src/snapper/chrome.go
@@ -17,7 +17,7 @@ func LaunchChrome(path *string) (*exec.Cmd, error) {
 			var err error
 			chromePath, err = filepath.Abs("./headless-chrome/headless_shell")
 			if err != nil {
-				log.Printf("Could not resolve chrome path: %s\n", err)
+				log.Printf("Could not resolve chrome path: %s", err)
 				return nil, err
 			}
 			args = append(args, "--window-size=1280x1696", "--no-sandbox", "--user-data-dir=/tmp/user-data",
@@ -27,12 +27,12 @@ func LaunchChrome(path *string) (*exec.Cmd, error) {
 	} else {
 		chromePath = *path
 	}
-	log.Printf("Launching %s %s\n", chromePath, args)
+	log.Printf("Launching %s %s", chromePath, args)
 	cmd := exec.Command(chromePath, args...)
 
 	err := cmd.Start()
 	if err != nil {
-		log.Printf("Error starting chrome: %s\n", err)
+		log.Printf("Error starting chrome: %s", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
I've presented this as my geese week project: support massive PDF downloads without interruptions.

There were issues while downloading multiple reviews within a single review group, where the process interrupts constantly due to "overloading", requiring to wait for server to recover/restart or for manual intervention to make a change in configuration (e.g. memory) to force the aws lambda service to restart and start clean, allowing another set of continous runs (~60) until the next interruption, and so on.

* `go version` > `go version go1.16 darwin/amd64`
* delete all @ `./server/src/` except `src/snapper`.
* `ls /usr/local/go/src`
* `ls /Users/car092920/go/src`
* `ls /Users/car092920/snapper/server`
* `go env -w GO111MODULE=auto`
* `go env -w GOPATH=/Users/car092920/snapper/server`
* `pwd` > `/Users/car092920/snapper/server`
* `go get ./...`
* (repeat `go get ./...` until no errors) ?
* `make clean`
* `make snapper.zip`
* upload `snapper_v2.zip` via `Upload from > .zip file` (then `Upload`, select file, and `Save`) @ https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/pdf-printer?tab=code
* alternataively upload via S3.
* you can also use `pdfprinter-dev` version (instead of production version above) @ https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/pdf-printer-dev?tab=code

Update on my journey with pdf printer on aws lambda (1on1 conversation with Tony via teams) ...

The original problem (re downloading pdf reviews in bulk) manifested by interruptions on around 50 downloads, without giving any clues, until opening the browser console and realizing the following error:
  "Uncaught DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded."
This required to wait for several minutes until another aws lambda was started (effectively replacing the current one and starting fresh), then reloading the page on the failed iteration to resume.
Then I also realized we could force the aws lambda restart by changing one of the parameters in the configuration (e.g. memory), which helped avoid the minutes wait and could resume almost immediately, but still with the error and requiring manual intervention.

Anyways, after the initial issues on setting up pdf printer on my local environment (thanks for your help), I finally managed to get snapper (pdfprinter-dev) up and running on aws lambda (solving cors and such).
I did lots of testing, reproducing the issue from my local environment connecting to aws lambda @ https://pdfprinter.7geese.com/pdfprinter-dev .
The actual error is: "cdp.Page: PrintToPDF: rpcc: the connection is closing: websocket: close 1006 (abnormal closure): unexpected EOF".

I investigated and tried so many things to attempt to resolve it (play with multiple versions of headless chrome, kill chrome process, change chrome flags, modify structs limits, adjust aws lambda configurations, and apply many many other recommendations), but nothing worked.
At some point, I managed to increase the crash threshold from ~60 to ~120, but again not nearly enough to satisfy large customers in the >1k reviews, and still requiring manual intervention.

I was about to give up (for the moment) when something else occurred to me:
The problem occurs while reusing an instance of aws lambda after certain number of times.
Then whey don't we also reuse the same headless chrome process (on every aws lambda instance) instead of launching on every invocation?.

So I made the necessary changes to snapper and voila it worked great!
I also researched if this was appropriate for aws lambdas and turns out it actually is.

Then I proceeded with sets of mass generations of PDF reviews, downloading from multiple browsers, each on an infinite loop to download a PDF review over and over.
Now "snapper_v2" supports thousands of invocations (without any limit?), with concurrency, very stable memory consumption, and better performance.

My biggest number has been ~8k invocations (without a single error) with up to 8 concurrent instances.

It could fail multiple times on first launch (for which I've increased the retries from 5 to 10).

I've successfully downloaded all 1,183 PDF reviews from Astreya's 2020 Review in both cannery-experimental (using `pdfprinter-dev`) and production (using `pdfprinter`), in about an hour.

In addition to downloading in a single pass without any errors or interruptions or manual intervention, it now performs better, with a stable memory consumption.